### PR TITLE
Enable remote logging

### DIFF
--- a/src/MLFlowClient.jl
+++ b/src/MLFlowClient.jl
@@ -49,7 +49,7 @@ export
     getorcreateexperiment,
     deleteexperiment,
     listexperiments
-    
+
 include("runs.jl")
 export
     createrun,

--- a/src/types.jl
+++ b/src/types.jl
@@ -6,10 +6,11 @@ Base type which defines location and version for MLFlow API service.
 # Fields
 - `baseuri::String`: base MLFlow tracking URI, e.g. `http://localhost:5000`
 - `apiversion`: used API version, e.g. `2.0`
+- `headers`: HTTP headers to be provided with the REST API requests (useful for authetication tokens)
 
 # Constructors
 
-- `MLFlow(baseuri; apiversion=2.0)`
+- `MLFlow(baseuri; apiversion=2.0,headers=Dict())`
 - `MLFlow()` - defaults to `MLFlow("http://localhost:5000")`
 
 # Examples
@@ -18,14 +19,21 @@ Base type which defines location and version for MLFlow API service.
 mlf = MLFlow()
 ```
 
+```@example
+ENV["DATABRICKS_HOST"]="https://<your-server>.cloud.databricks.com"; # address of your remote server
+ENV["DATABRICKS_TOKEN"]="<your-secret-PAT>"; # Personal Access Token
+mlf = MLFlow(ENV["DATABRICKS_HOST"]; headers=Dict("Authorization" => "Bearer $(ENV["DATABRICKS_TOKEN"])"))
+```
+
 """
 struct MLFlow
     baseuri::String
     apiversion
+    headers::Dict
 end
-MLFlow(baseuri; apiversion=2.0) = MLFlow(baseuri, apiversion)
-MLFlow() = MLFlow("http://localhost:5000", 2.0)
-Base.show(io::IO, t::MLFlow) = show(io, ShowCase(t, new_lines=true))
+MLFlow(baseuri; apiversion=2.0,headers=Dict()) = MLFlow(baseuri, apiversion,headers)
+MLFlow() = MLFlow("http://localhost:5000", 2.0, Dict())
+Base.show(io::IO, t::MLFlow) = show(io, ShowCase(t, [:baseuri,:apiversion], new_lines=true))
 
 """
     MLFlowExperiment

--- a/src/types.jl
+++ b/src/types.jl
@@ -20,9 +20,8 @@ mlf = MLFlow()
 ```
 
 ```@example
-ENV["DATABRICKS_HOST"]="https://<your-server>.cloud.databricks.com"; # address of your remote server
-ENV["DATABRICKS_TOKEN"]="<your-secret-PAT>"; # Personal Access Token
-mlf = MLFlow(ENV["DATABRICKS_HOST"]; headers=Dict("Authorization" => "Bearer $(ENV["DATABRICKS_TOKEN"])"))
+remote_url="https://<your-server>.cloud.databricks.com"; # address of your remote server
+mlf = MLFlow(remote_url, headers=Dict("Authorization" => "Bearer <your-secret-token>"))
 ```
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -18,6 +18,11 @@ end
     headers(mlf::MLFlow,custom_headers::AbstractDict)
 
 Retrieves HTTP headers based on `mlf` and merges with user-provided `custom_headers`
+
+# Examples
+```@example
+headers(mlf,Dict("Content-Type"=>"application/json"))
+```
 """
 headers(mlf::MLFlow,custom_headers::AbstractDict)=merge(mlf.headers, custom_headers)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -15,15 +15,22 @@ function uri(mlf::MLFlow, endpoint="", query=missing)
 end
 
 """
+    headers(mlf::MLFlow,custom_headers::AbstractDict)
+
+Retrieves HTTP headers based on `mlf` and merges with user-provided `custom_headers`
+"""
+headers(mlf::MLFlow,custom_headers::AbstractDict)=merge(mlf.headers, custom_headers)
+
+"""
     mlfget(mlf, endpoint; kwargs...)
 
 Performs a HTTP GET to a specifid endpoint. kwargs are turned into GET params.
 """
 function mlfget(mlf, endpoint; kwargs...)
     apiuri = uri(mlf, endpoint, kwargs)
-    headers = ["Content-Type: application/json"]
+    apiheaders = headers(mlf,Dict("Content-Type"=>"application/json"))
     try
-        response = HTTP.get(apiuri, headers)
+        response = HTTP.get(apiuri, apiheaders)
         return JSON.parse(String(response.body))
     catch e
         throw(e)
@@ -37,10 +44,10 @@ Performs a HTTP POST to the specified endpoint. kwargs are converted to JSON and
 """
 function mlfpost(mlf, endpoint; kwargs...)
     apiuri = uri(mlf, endpoint)
-    headers = ["Content-Type: application/json"]
+    apiheaders = headers(mlf,Dict("Content-Type"=>"application/json"))
     body = JSON.json(kwargs)
     try
-        response = HTTP.post(apiuri, headers, body)
+        response = HTTP.post(apiuri, apiheaders, body)
         return JSON.parse(String(response.body))
     catch e
         throw(e)

--- a/test/test_functional.jl
+++ b/test/test_functional.jl
@@ -4,9 +4,17 @@ include("test_base.jl")
     mlf = MLFlow()
     @test mlf.baseuri == "http://localhost:5000"
     @test mlf.apiversion == 2.0
+    @test mlf.headers == Dict()
     mlf = MLFlow("https://localhost:5001", apiversion=3.0)
     @test mlf.baseuri == "https://localhost:5001"
     @test mlf.apiversion == 3.0
+    @test mlf.headers == Dict()
+    let custom_headers=Dict("Authorization"=>"Bearer EMPTY")
+        mlf = MLFLow("https://localhost:5001", apiversion=3.0,headers=custom_headers)
+        @test mlf.baseuri == "https://localhost:5001"
+        @test mlf.apiversion == 3.0
+        @test mlf.headers == custom_headers
+    end
 end
 
 @testset "createexperiment" begin

--- a/test/test_functional.jl
+++ b/test/test_functional.jl
@@ -33,6 +33,22 @@ end
     end
 end
 
+@testset "utils" begin
+    using MLFlowClient: uri, headers
+    using URIs: URI
+    let baseuri = "http://localhost:5001", apiversion = "2.0", endpoint = "experiments/get"
+        mlf = MLFlow(baseuri; apiversion)
+        apiuri = uri(mlf, endpoint)
+        @test apiuri == URI("$baseuri/api/$apiversion/mlflow/$endpoint")
+    end
+    let baseuri = "http://localhost:5001", auth_headers = Dict("Authorization" => "Bearer 123456"),
+        custom_headers = Dict("Content-Type" => "application/json")
+        mlf = MLFlow(baseuri; headers=auth_headers)
+        apiheaders = headers(mlf, custom_headers)
+        @test apiheaders == Dict("Authorization" => "Bearer 123456", "Content-Type" => "application/json")
+    end
+end
+
 @testset "createexperiment" begin
     @ensuremlf
     exp = createexperiment(mlf)
@@ -144,7 +160,7 @@ end
         artifactpath = logartifact(mlf, exprun, joinpath("newdir", "new2", "new3", "new4", "randbytesindir2.bin"), b"bytes here")
 
         # artifact tree should now look like this:
-        # 
+        #
         # ├── newdir
         # │   ├── new2
         # │   │   ├── new3
@@ -217,7 +233,7 @@ end
     @test running_run.info.status == MLFlowRunStatus("RUNNING")
     finished_run = updaterun(mlf, exprun, MLFlowRunStatus("FINISHED"))
     finishedrun = getrun(mlf, finished_run.info.run_id)
-    
+
     @test !ismissing(finishedrun.info.end_time)
 
     exprun2 = createrun(mlf, experiment_id)

--- a/test/test_functional.jl
+++ b/test/test_functional.jl
@@ -10,10 +10,26 @@ include("test_base.jl")
     @test mlf.apiversion == 3.0
     @test mlf.headers == Dict()
     let custom_headers=Dict("Authorization"=>"Bearer EMPTY")
-        mlf = MLFLow("https://localhost:5001", apiversion=3.0,headers=custom_headers)
+        mlf = MLFlow("https://localhost:5001", apiversion=3.0,headers=custom_headers)
         @test mlf.baseuri == "https://localhost:5001"
         @test mlf.apiversion == 3.0
         @test mlf.headers == custom_headers
+    end
+end
+
+# test that sensitive fields are not displayed by show()
+@testset "MLFLow/show" begin
+    let io=IOBuffer(),
+        secret_token="SECRET"
+
+        custom_headers=Dict("Authorization"=>"Bearer $secret_token")
+        mlf = MLFlow("https://localhost:5001", apiversion=3.0,headers=custom_headers)
+        @test mlf.baseuri == "https://localhost:5001"
+        @test mlf.apiversion == 3.0
+        @test mlf.headers == custom_headers
+        show(io,mlf)
+        show_output=String(take!(io))
+        @test !(occursin(secret_token,show_output))
     end
 end
 

--- a/test/test_issue17.jl
+++ b/test/test_issue17.jl
@@ -6,8 +6,8 @@ include("test_base.jl")
 
     mlf_experiment = getorcreateexperiment(mlf, "issue17")
     mlf_run = createrun(
-        mlf, 
-        mlf_experiment, 
+        mlf,
+        mlf_experiment,
         tags=[
             Dict(
                 "key" => "mlflow.runName",


### PR DESCRIPTION
TL;DR This is a proposal to enable remote logging (eg, Databricks or internal MLFlow servers)

Closes #21 

Implementation: 
- It extends the basic constructor with a keyword field `headers`, where user can provide authentication details for their remote server (eg, basic auth, bearer)
- Given its sensitive nature, this field `headers` has been hidden from the pretty-print (ShowCase)