### PR TITLE
Bumped up compat for HTTP.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 FilePathsBase = "0.9"
-HTTP = "0.9"
+HTTP = "0.9,1.2"
 JSON = "0.21"
 ShowCases = "0.1"
 URIs = "1"


### PR DESCRIPTION
Would it be possible to increase the compat for HTTP.jl to 1.2? 
I've re-run the testing suite and all passes

Motivation:
MLFlow-based workflows are more likely to have connection timeouts, which leads to a lot of HTTP.jl errors like `IOError(EOFError())` (eg, https://github.com/JuliaWeb/HTTP.jl/issues/233)

There have been a lot of fixes in HTTP.lj since version 0.9 (see https://github.com/JuliaWeb/HTTP.jl/issues/903), so we would be able to benefit from that.