### PR TITLE
Sending the executions in UTC-0 (rel. issue 20)

### DIFF
--- a/src/runs.jl
+++ b/src/runs.jl
@@ -17,7 +17,7 @@ Creates a run associated to an experiment.
 function createrun(mlf::MLFlow, experiment_id; start_time=missing, tags=missing)
     endpoint = "runs/create"
     if ismissing(start_time)
-        start_time = Int(trunc(datetime2unix(now()) * 1000))
+        start_time = Int(trunc(datetime2unix(now(UTC)) * 1000))
     end
     result = mlfpost(mlf, endpoint; experiment_id=experiment_id, start_time=start_time, tags=tags)
     MLFlowRun(result["run"]["info"], result["run"]["data"])
@@ -69,7 +69,7 @@ function updaterun(mlf::MLFlow, run_id::String, status::MLFlowRunStatus; end_tim
         :end_time => end_time
     )
     if ismissing(end_time) && status.status == "FINISHED"
-        end_time = Int(trunc(datetime2unix(now()) * 1000))
+        end_time = Int(trunc(datetime2unix(now(UTC)) * 1000))
         kwargs[:end_time] = string(end_time)
     end
     result = mlfpost(mlf, endpoint; kwargs...)
@@ -233,7 +233,7 @@ Logs a metric value (or values) against a particular run.
 function logmetric(mlf::MLFlow, run_id::String, key, value::T; timestamp=missing, step=missing) where T<:Real
     endpoint = "runs/log-metric"
     if ismissing(timestamp)
-        timestamp = Int(trunc(datetime2unix(now()) * 1000))
+        timestamp = Int(trunc(datetime2unix(now(UTC)) * 1000))
     end
     mlfpost(mlf, endpoint; run_id=run_id, key=key, value=value, timestamp=timestamp, step=step)
 end

--- a/test/issues/test_issue17.jl
+++ b/test/issues/test_issue17.jl
@@ -1,5 +1,5 @@
 # Addresses https://github.com/JuliaAI/MLFlowClient.jl/issues/17
-include("test_base.jl")
+include("../test_base.jl")
 
 @testset "Issue17" begin
     @ensuremlf

--- a/test/issues/test_issue20.jl
+++ b/test/issues/test_issue20.jl
@@ -1,0 +1,19 @@
+# Addresses https://github.com/JuliaAI/MLFlowClient.jl/issues/20
+include("../test_base.jl")
+
+@testset "Issue20" begin
+    @ensuremlf
+
+    mlf_experiment = getorcreateexperiment(mlf, "issue20")
+    mlf_run = createrun(
+        mlf,
+        mlf_experiment,
+        tags=[
+            Dict(
+                "key" => "mlflow.runName",
+                "value" => "run_name"
+            )
+        ]
+    )
+    @test isa(mlf_run, MLFlowRun)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,2 @@
 include("test_functional.jl")
-include("test_issue17.jl")
+include.(filter(contains(r".jl$"), readdir("./issues"; join=true)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,2 @@
 include("test_functional.jl")
-include.(filter(contains(r".jl$"), readdir("./issues"; join=true)))
+include.(filter(contains(r"\.jl$"), readdir("./issues"; join=true)))


### PR DESCRIPTION
- MLFlow executions need to be tracked in UTC-0
- An extra effort regarding issues tests in an extra directory.

Note:
MLFlow dashboard shows the local UTC configuration, meaning that we are not going to be able to see changes (unless we change to another machine with another timezone).