### PR TITLE
Migrating from /api to /ajax-api endpoint

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -25,7 +25,7 @@ MLFlowClient.uri(mlf, "experiments/get", Dict(:experiment_id=>10))
 ```
 """
 function uri(mlf::MLFlow, endpoint="", query=missing)
-    u = URI("$(mlf.baseuri)/api/$(mlf.apiversion)/mlflow/$(endpoint)")
+    u = URI("$(mlf.baseuri)/ajax-api/$(mlf.apiversion)/mlflow/$(endpoint)")
     !ismissing(query) && return URI(u; query=query)
     u
 end

--- a/test/test_functional.jl
+++ b/test/test_functional.jl
@@ -40,7 +40,7 @@ end
     let baseuri = "http://localhost:5001", apiversion = "2.0", endpoint = "experiments/get"
         mlf = MLFlow(baseuri; apiversion)
         apiuri = uri(mlf, endpoint)
-        @test apiuri == URI("$baseuri/api/$apiversion/mlflow/$endpoint")
+        @test apiuri == URI("$baseuri/ajax-api/$apiversion/mlflow/$endpoint")
     end
     let baseuri = "http://localhost:5001", auth_headers = Dict("Authorization" => "Bearer 123456"),
         custom_headers = Dict("Content-Type" => "application/json")


### PR DESCRIPTION
The `/ajax-api` prefix is used by `Dagshub` to connect to the REST API. This is giving exactly the same responses as the previous `/api` prefix. This solves https://github.com/JuliaAI/MLFlowClient.jl/issues/35#issuecomment-1880158336.

I don't know the existance of both, but we must go through the one that is compatible with both solutions. In the future, if there's a case that is breaking this, we should think in a way to separate each different platform.