### PR TITLE
Adding `use_ajax` flag to `MLFlow` instances

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
-          MLFLOW_TRACKING_URI: "http://localhost:5000"
+          MLFLOW_API_URI: "http://localhost:5000/api"
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v2
         with:

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -56,5 +56,4 @@ uri
 generatefilterfromentity_type
 generatefilterfromparams
 generatefilterfromattributes
-healthcheck
 ```

--- a/src/types/mlflow.jl
+++ b/src/types/mlflow.jl
@@ -12,7 +12,7 @@ Default is `false`, using the REST API endpoint.
 # Constructors
 
 - `MLFlow(apiroot; apiversion=2.0,headers=Dict())`
-- `MLFlow()` - defaults to `MLFlow(ENV["MLFLOW_TRACKING_URI"])` or `MLFlow("http://localhost:5000")`
+- `MLFlow()` - defaults to `MLFlow(ENV["MLFLOW_API_URI"])` or `MLFlow("http://localhost:5000")`
 
 # Examples
 
@@ -34,8 +34,8 @@ end
 MLFlow(apiroot; apiversion=2.0, headers=Dict()) = MLFlow(apiroot, apiversion, headers)
 function MLFlow()
     apiroot = "http://localhost:5000/api"
-    if haskey(ENV, "MLFLOW_TRACKING_URI")
-        apiroot = ENV["MLFLOW_TRACKING_URI"]
+    if haskey(ENV, "MLFLOW_API_URI")
+        apiroot = ENV["MLFLOW_API_URI"]
     end
     return MLFlow(apiroot)
 end

--- a/src/types/mlflow.jl
+++ b/src/types/mlflow.jl
@@ -5,12 +5,14 @@ Base type which defines location and version for MLFlow API service.
 
 # Fields
 - `baseuri::String`: base MLFlow tracking URI, e.g. `http://localhost:5000`
-- `apiversion`: used API version, e.g. `2.0`
-- `headers`: HTTP headers to be provided with the REST API requests (useful for authetication tokens)
+- `apiversion::Union{Integer, AbstractFloat}`: used API version, e.g. `2.0`
+- `headers::Dict`: HTTP headers to be provided with the REST API requests (useful for authetication tokens)
+- `use_ajax::Bool`: whether to use the AJAX endpoint for the MLFlow service.
+Default is `false`, using the REST API endpoint.
 
 # Constructors
 
-- `MLFlow(baseuri; apiversion=2.0,headers=Dict())`
+- `MLFlow(baseuri; apiversion=2.0,headers=Dict(),use_ajax=false)`
 - `MLFlow()` - defaults to `MLFlow(ENV["MLFLOW_TRACKING_URI"])` or `MLFlow("http://localhost:5000")`
 
 # Examples
@@ -29,8 +31,9 @@ struct MLFlow
     baseuri::String
     apiversion::Union{Integer, AbstractFloat}
     headers::Dict
+    use_ajax::Bool
 end
-MLFlow(baseuri; apiversion=2.0,headers=Dict()) = MLFlow(baseuri, apiversion,headers)
+MLFlow(baseuri; apiversion=2.0, headers=Dict(), use_ajax=false) = MLFlow(baseuri, apiversion, headers, use_ajax)
 function MLFlow()
     baseuri = "http://localhost:5000"
     if haskey(ENV, "MLFLOW_TRACKING_URI")
@@ -38,5 +41,4 @@ function MLFlow()
     end
     return MLFlow(baseuri)
 end
-
 Base.show(io::IO, t::MLFlow) = show(io, ShowCase(t, [:baseuri,:apiversion], new_lines=true))

--- a/src/types/mlflow.jl
+++ b/src/types/mlflow.jl
@@ -4,15 +4,14 @@
 Base type which defines location and version for MLFlow API service.
 
 # Fields
-- `baseuri::String`: base MLFlow tracking URI, e.g. `http://localhost:5000`
+- `apiroot::String`: API root URL, e.g. `http://localhost:5000/api`
 - `apiversion::Union{Integer, AbstractFloat}`: used API version, e.g. `2.0`
 - `headers::Dict`: HTTP headers to be provided with the REST API requests (useful for authetication tokens)
-- `use_ajax::Bool`: whether to use the AJAX endpoint for the MLFlow service.
 Default is `false`, using the REST API endpoint.
 
 # Constructors
 
-- `MLFlow(baseuri; apiversion=2.0,headers=Dict(),use_ajax=false)`
+- `MLFlow(apiroot; apiversion=2.0,headers=Dict())`
 - `MLFlow()` - defaults to `MLFlow(ENV["MLFLOW_TRACKING_URI"])` or `MLFlow("http://localhost:5000")`
 
 # Examples
@@ -28,17 +27,16 @@ mlf = MLFlow(remote_url, headers=Dict("Authorization" => "Bearer <your-secret-to
 
 """
 struct MLFlow
-    baseuri::String
+    apiroot::String
     apiversion::Union{Integer, AbstractFloat}
     headers::Dict
-    use_ajax::Bool
 end
-MLFlow(baseuri; apiversion=2.0, headers=Dict(), use_ajax=false) = MLFlow(baseuri, apiversion, headers, use_ajax)
+MLFlow(apiroot; apiversion=2.0, headers=Dict()) = MLFlow(apiroot, apiversion, headers)
 function MLFlow()
-    baseuri = "http://localhost:5000"
+    apiroot = "http://localhost:5000/api"
     if haskey(ENV, "MLFLOW_TRACKING_URI")
-        baseuri = ENV["MLFLOW_TRACKING_URI"]
+        apiroot = ENV["MLFLOW_TRACKING_URI"]
     end
-    return MLFlow(baseuri)
+    return MLFlow(apiroot)
 end
-Base.show(io::IO, t::MLFlow) = show(io, ShowCase(t, [:baseuri,:apiversion], new_lines=true))
+Base.show(io::IO, t::MLFlow) = show(io, ShowCase(t, [:apiroot,:apiversion], new_lines=true))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -25,7 +25,8 @@ MLFlowClient.uri(mlf, "experiments/get", Dict(:experiment_id=>10))
 ```
 """
 function uri(mlf::MLFlow, endpoint="", query=missing)
-    u = URI("$(mlf.baseuri)/ajax-api/$(mlf.apiversion)/mlflow/$(endpoint)")
+    api_endpoint = mlf.use_ajax ? "ajax-api" : "api"
+    u = URI("$(mlf.baseuri)/$(api_endpoint)/$(mlf.apiversion)/mlflow/$(endpoint)")
     !ismissing(query) && return URI(u; query=query)
     u
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -25,8 +25,7 @@ MLFlowClient.uri(mlf, "experiments/get", Dict(:experiment_id=>10))
 ```
 """
 function uri(mlf::MLFlow, endpoint="", query=missing)
-    api_endpoint = mlf.use_ajax ? "ajax-api" : "api"
-    u = URI("$(mlf.baseuri)/$(api_endpoint)/$(mlf.apiversion)/mlflow/$(endpoint)")
+    u = URI("$(mlf.apiroot)/$(mlf.apiversion)/mlflow/$(endpoint)")
     !ismissing(query) && return URI(u; query=query)
     u
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,20 +1,4 @@
 """
-    healthcheck(mlf::MLFlow)
-
-Checks if MLFlow server is up and running. Returns `true` if it is, `false`
-otherwise.
-"""
-function healthcheck(mlf)
-    uri = "$(mlf.baseuri)/health"
-    try
-        response = HTTP.get(uri)
-        return String(response.body) == "OK"
-    catch e
-        return false
-    end
-end
-
-"""
     uri(mlf::MLFlow, endpoint="", query=missing)
 
 Retrieves an URI based on `mlf`, `endpoint`, and, optionally, `query`.

--- a/test/base.jl
+++ b/test/base.jl
@@ -13,7 +13,7 @@ function mlflow_server_is_running(mlf::MLFlow)
 end
 
 # creates an instance of mlf
-# skips test if mlflow is not available on default location, ENV["MLFLOW_TRACKING_URI"]
+# skips test if mlflow is not available on default location, ENV["MLFLOW_API_URI"]
 macro ensuremlf()
     e = quote
         mlf = MLFlow()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,7 @@
+if ~haskey(ENV, "MLFLOW_API_URI")
+    error("WARNING: MLFLOW_API_URI is not set. To run this tests, you need to set the URI of your MLFlow server API")
+end
+
 include("base.jl")
 
 include("test_functional.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 include("base.jl")
 
+include("test_functional.jl")
 include("test_experiments.jl")
 include("test_runs.jl")
 include("test_loggers.jl")

--- a/test/test_functional.jl
+++ b/test/test_functional.jl
@@ -1,6 +1,6 @@
 @testset "MLFlow" begin
     mlf = MLFlow()
-    @test mlf.apiroot == ENV["MLFLOW_TRACKING_URI"]
+    @test mlf.apiroot == ENV["MLFLOW_API_URI"]
     @test mlf.apiversion == 2.0
     @test mlf.headers == Dict()
     mlf = MLFlow("https://localhost:5001/api", apiversion=3.0)

--- a/test/test_functional.jl
+++ b/test/test_functional.jl
@@ -35,10 +35,12 @@ end
     using MLFlowClient: uri, headers
     using URIs: URI
 
-    @test healthcheck(MLFlow()) == true
+    let baseuri = "http://localhost:5001", apiversion = 2.0, endpoint = "experiments/get"
+        mlf = MLFlow(baseuri; apiversion=apiversion)
+        apiuri = uri(mlf, endpoint)
+        @test apiuri == URI("$baseuri/api/$apiversion/mlflow/$endpoint")
 
-    let baseuri = "http://localhost:5001", apiversion = "2.0", endpoint = "experiments/get"
-        mlf = MLFlow(baseuri; apiversion)
+        mlf = MLFlow(baseuri; apiversion=apiversion, use_ajax=true)
         apiuri = uri(mlf, endpoint)
         @test apiuri == URI("$baseuri/ajax-api/$apiversion/mlflow/$endpoint")
     end

--- a/test/test_functional.jl
+++ b/test/test_functional.jl
@@ -1,15 +1,15 @@
 @testset "MLFlow" begin
     mlf = MLFlow()
-    @test mlf.baseuri == ENV["MLFLOW_TRACKING_URI"]
+    @test mlf.apiroot == ENV["MLFLOW_TRACKING_URI"]
     @test mlf.apiversion == 2.0
     @test mlf.headers == Dict()
-    mlf = MLFlow("https://localhost:5001", apiversion=3.0)
-    @test mlf.baseuri == "https://localhost:5001"
+    mlf = MLFlow("https://localhost:5001/api", apiversion=3.0)
+    @test mlf.apiroot == "https://localhost:5001/api"
     @test mlf.apiversion == 3.0
     @test mlf.headers == Dict()
     let custom_headers = Dict("Authorization" => "Bearer EMPTY")
-        mlf = MLFlow("https://localhost:5001", apiversion=3.0, headers=custom_headers)
-        @test mlf.baseuri == "https://localhost:5001"
+        mlf = MLFlow("https://localhost:5001/api", apiversion=3.0, headers=custom_headers)
+        @test mlf.apiroot == "https://localhost:5001/api"
         @test mlf.apiversion == 3.0
         @test mlf.headers == custom_headers
     end
@@ -21,8 +21,8 @@ end
         secret_token = "SECRET"
 
         custom_headers = Dict("Authorization" => "Bearer $secret_token")
-        mlf = MLFlow("https://localhost:5001", apiversion=3.0, headers=custom_headers)
-        @test mlf.baseuri == "https://localhost:5001"
+        mlf = MLFlow("https://localhost:5001/api", apiversion=3.0, headers=custom_headers)
+        @test mlf.apiroot == "https://localhost:5001/api"
         @test mlf.apiversion == 3.0
         @test mlf.headers == custom_headers
         show(io, mlf)
@@ -35,19 +35,15 @@ end
     using MLFlowClient: uri, headers
     using URIs: URI
 
-    let baseuri = "http://localhost:5001", apiversion = 2.0, endpoint = "experiments/get"
-        mlf = MLFlow(baseuri; apiversion=apiversion)
+    let apiroot = "http://localhost:5001/api", apiversion = 2.0, endpoint = "experiments/get"
+        mlf = MLFlow(apiroot; apiversion=apiversion)
         apiuri = uri(mlf, endpoint)
-        @test apiuri == URI("$baseuri/api/$apiversion/mlflow/$endpoint")
-
-        mlf = MLFlow(baseuri; apiversion=apiversion, use_ajax=true)
-        apiuri = uri(mlf, endpoint)
-        @test apiuri == URI("$baseuri/ajax-api/$apiversion/mlflow/$endpoint")
+        @test apiuri == URI("$apiroot/$apiversion/mlflow/$endpoint")
     end
-    let baseuri = "http://localhost:5001", auth_headers = Dict("Authorization" => "Bearer 123456"),
+    let apiroot = "http://localhost:5001/api", auth_headers = Dict("Authorization" => "Bearer 123456"),
         custom_headers = Dict("Content-Type" => "application/json")
 
-        mlf = MLFlow(baseuri; headers=auth_headers)
+        mlf = MLFlow(apiroot; headers=auth_headers)
         apiheaders = headers(mlf, custom_headers)
         @test apiheaders == Dict("Authorization" => "Bearer 123456", "Content-Type" => "application/json")
     end


### PR DESCRIPTION
Alowing compatibility with both `REST` and `AJAX` endpoints.