### PR TITLE
Improve documentation clarity for `tags` variable and update type in function definition.

### DIFF
--- a/src/experiments.jl
+++ b/src/experiments.jl
@@ -1,5 +1,5 @@
 """
-    createexperiment(mlf::MLFlow; name=missing, artifact_location=missing, tags=missing)
+    createexperiment(mlf::MLFlow; name=missing, artifact_location=missing, tags::Vector{Dict{String, String}}=missing)
 
 Creates an MLFlow experiment.
 
@@ -7,13 +7,14 @@ Creates an MLFlow experiment.
 - `mlf`: [`MLFlow`](@ref) configuration.
 - `name`: experiment name. If not specified, MLFlow sets it.
 - `artifact_location`: directory where artifacts of this experiment will be stored. If not specified, MLFlow uses its default configuration.
-- `tags`: a Dictionary of key-values which tag the experiment.
+- `tags`: a Vector of Dictionaries which tag the experiment.
+    - example tags: [Dict("key" => "foo", "value" => "bar"), Dict("key" => "missy", "value" => "gala")]
 
 # Returns
 An object of type [`MLFlowExperiment`](@ref).
 
 """
-function createexperiment(mlf::MLFlow; name=missing, artifact_location=missing, tags=missing)
+function createexperiment(mlf::MLFlow; name=missing, artifact_location=missing, tags::Vector{Dict{String, String}}=missing)
     endpoint = "experiments/create"
 
     if ismissing(name)
@@ -89,7 +90,7 @@ function getexperiment(mlf::MLFlow, experiment_name::String)
 end
 
 """
-    getorcreateexperiment(mlf::MLFlow, experiment_name::String; artifact_location=missing, tags=missing)
+    getorcreateexperiment(mlf::MLFlow, experiment_name::String; artifact_location=missing, tags::Vector{Dict{String, String}}=missing)
 
 Gets an experiment if one alrady exists, or creates a new one.
 
@@ -97,13 +98,14 @@ Gets an experiment if one alrady exists, or creates a new one.
 - `mlf`: [`MLFlow`](@ref) configuration.
 - `experiment_name`: Experiment name.
 - `artifact_location`: directory where artifacts of this experiment will be stored. If not specified, MLFlow uses its default configuration.
-- `tags`: a Dictionary of key-values which tag the experiment.
+- `tags`: a Vector of Dictionaries which tag the experiment.
+    - example tags: [Dict("key" => "foo", "value" => "bar"), Dict("key" => "missy", "value" => "gala")]
 
 # Returns
 An instance of type [`MLFlowExperiment`](@ref)
 
 """
-function getorcreateexperiment(mlf::MLFlow, experiment_name::String; artifact_location=missing, tags=missing)
+function getorcreateexperiment(mlf::MLFlow, experiment_name::String; artifact_location=missing, tags::Vector{Dict{String, String}}=missing)
     experiment = getexperiment(mlf, experiment_name)
 
     if ismissing(experiment)

--- a/src/experiments.jl
+++ b/src/experiments.jl
@@ -1,5 +1,5 @@
 """
-    createexperiment(mlf::MLFlow; name=missing, artifact_location=missing, tags::Vector{Dict{String, String}}=missing)
+    createexperiment(mlf::MLFlow; name=missing, artifact_location=missing, tags=missing)
 
 Creates an MLFlow experiment.
 
@@ -14,7 +14,7 @@ Creates an MLFlow experiment.
 An object of type [`MLFlowExperiment`](@ref).
 
 """
-function createexperiment(mlf::MLFlow; name=missing, artifact_location=missing, tags::Vector{Dict{String, String}}=missing)
+function createexperiment(mlf::MLFlow; name=missing, artifact_location=missing, tags=missing)
     endpoint = "experiments/create"
 
     if ismissing(name)
@@ -90,7 +90,7 @@ function getexperiment(mlf::MLFlow, experiment_name::String)
 end
 
 """
-    getorcreateexperiment(mlf::MLFlow, experiment_name::String; artifact_location=missing, tags::Vector{Dict{String, String}}=missing)
+    getorcreateexperiment(mlf::MLFlow, experiment_name::String; artifact_location=missing, tags=missing)
 
 Gets an experiment if one alrady exists, or creates a new one.
 
@@ -105,7 +105,7 @@ Gets an experiment if one alrady exists, or creates a new one.
 An instance of type [`MLFlowExperiment`](@ref)
 
 """
-function getorcreateexperiment(mlf::MLFlow, experiment_name::String; artifact_location=missing, tags::Vector{Dict{String, String}}=missing)
+function getorcreateexperiment(mlf::MLFlow, experiment_name::String; artifact_location=missing, tags=missing)
     experiment = getexperiment(mlf, experiment_name)
 
     if ismissing(experiment)

--- a/src/runs.jl
+++ b/src/runs.jl
@@ -10,12 +10,13 @@ Creates a run associated to an experiment.
 # Keywords
 - `run_name`: run name. If not specified, MLFlow sets it.
 - `start_time`: if provided, must be a UNIX timestamp in milliseconds. By default, set to current time.
-- `tags`: if provided, must be a key-value structure such as a dictionary.
+- `tags`: if provided, must be a key-value structure such as for example:
+    - [Dict("key" => "foo", "value" => "bar"), Dict("key" => "missy", "value" => "gala")]
 
 # Returns
 - an instance of type [`MLFlowRun`](@ref)
 """
-function createrun(mlf::MLFlow, experiment_id; run_name=missing, start_time=missing, tags=missing)
+function createrun(mlf::MLFlow, experiment_id; run_name=missing, start_time=missing, tags::Vector{Dict{String, String}}=missing)
     endpoint = "runs/create"
     if ismissing(start_time)
         start_time = Int(trunc(datetime2unix(now(UTC)) * 1000))
@@ -24,11 +25,11 @@ function createrun(mlf::MLFlow, experiment_id; run_name=missing, start_time=miss
     MLFlowRun(result["run"]["info"], result["run"]["data"])
 end
 """
-    createrun(mlf::MLFlow, experiment::MLFlowExperiment; run_name=missing, start_time=missing, tags=missing)
+    createrun(mlf::MLFlow, experiment::MLFlowExperiment; run_name=missing, start_time=missing, tags::Vector{Dict{String, String}}=missing)
 
 Dispatches to `createrun(mlf::MLFlow, experiment_id; run_name=run_name, start_time=start_time, tags=tags)`
 """
-createrun(mlf::MLFlow, experiment::MLFlowExperiment; run_name=missing, start_time=missing, tags=missing) =
+createrun(mlf::MLFlow, experiment::MLFlowExperiment; run_name=missing, start_time=missing, tags::Vector{Dict{String, String}}=missing) =
     createrun(mlf, experiment.experiment_id; run_name=run_name, start_time=start_time, tags=tags)
 
 """

--- a/src/runs.jl
+++ b/src/runs.jl
@@ -16,7 +16,7 @@ Creates a run associated to an experiment.
 # Returns
 - an instance of type [`MLFlowRun`](@ref)
 """
-function createrun(mlf::MLFlow, experiment_id; run_name=missing, start_time=missing, tags::Vector{Dict{String, String}}=missing)
+function createrun(mlf::MLFlow, experiment_id; run_name=missing, start_time=missing, tags=missing)
     endpoint = "runs/create"
     if ismissing(start_time)
         start_time = Int(trunc(datetime2unix(now(UTC)) * 1000))
@@ -25,11 +25,11 @@ function createrun(mlf::MLFlow, experiment_id; run_name=missing, start_time=miss
     MLFlowRun(result["run"]["info"], result["run"]["data"])
 end
 """
-    createrun(mlf::MLFlow, experiment::MLFlowExperiment; run_name=missing, start_time=missing, tags::Vector{Dict{String, String}}=missing)
+    createrun(mlf::MLFlow, experiment::MLFlowExperiment; run_name=missing, start_time=missing, tags=missing)
 
 Dispatches to `createrun(mlf::MLFlow, experiment_id; run_name=run_name, start_time=start_time, tags=tags)`
 """
-createrun(mlf::MLFlow, experiment::MLFlowExperiment; run_name=missing, start_time=missing, tags::Vector{Dict{String, String}}=missing) =
+createrun(mlf::MLFlow, experiment::MLFlowExperiment; run_name=missing, start_time=missing, tags=missing) =
     createrun(mlf, experiment.experiment_id; run_name=run_name, start_time=start_time, tags=tags)
 
 """


### PR DESCRIPTION
**Summary:**
- Clarified the expected structure and content of the `tags` variable in the documentation.

**Changes:**
- Initially changed the type declaration of `tags` in the first commit, which caused errors in the test.
- Reverted the type declaration to maintain consistency with the library's style.

**Notes:**
- The type declaration was omitted to avoid test errors and adhere to the existing style of the library.