### PR TITLE
Auth using environment variables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["@deyandyankov, @pebeto, and contributors"]
 version = "0.5.1"
 
 [deps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
@@ -25,4 +26,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]
-

--- a/src/MLFlowClient.jl
+++ b/src/MLFlowClient.jl
@@ -15,6 +15,7 @@ module MLFlowClient
 using Dates
 using UUIDs
 using HTTP
+using HTTP.Base64
 using URIs
 using JSON
 using ShowCases

--- a/src/MLFlowClient.jl
+++ b/src/MLFlowClient.jl
@@ -15,7 +15,7 @@ module MLFlowClient
 using Dates
 using UUIDs
 using HTTP
-using HTTP.Base64
+using Base64
 using URIs
 using JSON
 using ShowCases

--- a/src/types/mlflow.jl
+++ b/src/types/mlflow.jl
@@ -11,7 +11,8 @@ Default is `false`, using the REST API endpoint.
 
 # Constructors
 
-- `MLFlow(apiroot; apiversion=2.0,headers=Dict())`
+- `MLFlow(apiroot; user, password, apiversion=2.0, headers=Dict())` - this constructor will check env 
+variables `MLFLOW_TRACKING_USERNAME` and `MLFLOW_TRACKING_PASSWORD` for credentials.
 - `MLFlow()` - defaults to `MLFlow(ENV["MLFLOW_TRACKING_URI"])` or `MLFlow("http://localhost:5000/api")`
 
 # Examples

--- a/src/types/mlflow.jl
+++ b/src/types/mlflow.jl
@@ -31,7 +31,21 @@ struct MLFlow
     apiversion::Union{Integer, AbstractFloat}
     headers::Dict
 end
-MLFlow(apiroot; apiversion=2.0, headers=Dict()) = MLFlow(apiroot, apiversion, headers)
+
+function MLFlow(
+    apiroot;
+    user=get(ENV, "MLFLOW_TRACKING_USERNAME", missing), 
+    password=get(ENV, "MLFLOW_TRACKING_PASSWORD", missing), 
+    apiversion=2.0, 
+    headers=Dict()
+    )
+    if !ismissing(user) && !ismissing(password)
+        token = base64encode("$(user):$(password)")
+        headers["Authorization"] = "Basic $(token)"
+    end
+    return MLFlow(apiroot, apiversion, headers)
+end
+
 function MLFlow()
     apiroot = "http://localhost:5000/api"
     if haskey(ENV, "MLFLOW_TRACKING_URI")


### PR DESCRIPTION
This PR modifies the default constructor to read environment variables `MLFLOW_TRACKING_USERNAME` and `MLFLOW_TRACKING_PASSWORD` for credentials and creates the Authorization header using basic auth.
