### PR TITLE
Fix updaterun API syntax in tutorial and examples

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -109,7 +109,7 @@ logartifact(mlf, exprun, plotfilename)
 rm(plotfilename)
 
 # complete the experiment
-updaterun(mlf, exprun, "FINISHED")
+updaterun(mlf, exprun; status=RunStatus.FINISHED)
 ```
 
 This will result in the folowing experiment created in your `MLFlow` which is running on `http://localhost/`:

--- a/examples/simple-with-mlflow.jl
+++ b/examples/simple-with-mlflow.jl
@@ -58,4 +58,4 @@ logartifact(mlf, exprun, plotfilename)
 rm(plotfilename)
 
 # complete the experiment
-updaterun(mlf, exprun, "FINISHED")
+updaterun(mlf, exprun; status=RunStatus.FINISHED)


### PR DESCRIPTION
## Summary
Fixes incorrect positional argument usage and string type for the `status` parameter in `updaterun` function calls.

## Changes
- Fixed `docs/src/tutorial.md:112`: Changed `updaterun(mlf, exprun, "FINISHED")` to `updaterun(mlf, exprun; status=RunStatus.FINISHED)`
- Fixed `examples/simple-with-mlflow.jl:61`: Applied same correction

## Problem
The tutorial and examples used incorrect syntax:
```julia
updaterun(mlf, exprun, "FINISHED")  # ❌ Wrong
```

But the actual method signature requires keyword arguments and enum types:
```julia
updaterun(instance::MLFlow, run::Run; status::Union{RunStatus.RunStatusEnum,Missing}=missing, ...)
```

## Solution
Updated to correct syntax:
```julia
updaterun(mlf, exprun; status=RunStatus.FINISHED)  # ✅ Correct
```

## Impact
- Fixes MethodError that users encounter when trying to complete runs
- Fixes type error from passing string instead of RunStatus enum
- Makes the tutorial examples functional for run completion
- Resolves the final step of the tutorial workflow

## Test plan
- [x] Verified method signature using `julia --project -e "using MLFlowClient; methods(updaterun)"`
- [x] Confirmed RunStatus.FINISHED is the correct enum value
- [x] Both tutorial and example files updated consistently

Fixes #64

🤖 Generated with [Claude Code](https://claude.ai/code)