### PR TITLE
Fix logmetric array handling in tutorial and examples

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -95,7 +95,10 @@ for (idx, pricepath) in enumerate(pricepaths)
         ylabel="Price"
     )
 
-    logmetric(mlf, exprun, "pricepath$(idx)", pricepath)
+    # Log each point in the price path as a separate metric with step parameter
+    for (step, value) in enumerate(pricepath)
+        logmetric(mlf, exprun, "pricepath$(idx)", Float64(value); step=step-1)
+    end
 end
 
 # Save the price path plot as an image

--- a/examples/simple-with-mlflow.jl
+++ b/examples/simple-with-mlflow.jl
@@ -44,7 +44,10 @@ for (idx, pricepath) in enumerate(pricepaths)
         ylabel="Price"
     )
 
-    logmetric(mlf, exprun, "pricepath$(idx)", pricepath)
+    # Log each point in the price path as a separate metric with step parameter
+    for (step, value) in enumerate(pricepath)
+        logmetric(mlf, exprun, "pricepath$(idx)", Float64(value); step=step-1)
+    end
 end
 
 # Save the price path plot as an image


### PR DESCRIPTION
## Summary
Fixes type error where arrays were passed to `logmetric` instead of individual `Float64` values. Now properly logs each point in the price path as a separate metric with step parameters.

## Changes
- Fixed `docs/src/tutorial.md:98-101`: Replaced single `logmetric` call with loop through array values
- Fixed `examples/simple-with-mlflow.jl:47-50`: Applied same correction

## Problem
The tutorial and examples attempted to log entire arrays:
```julia
logmetric(mlf, exprun, "pricepath$(idx)", pricepath)  # ❌ pricepath is Array{Float64}
```

But `logmetric` only accepts single `Float64` values:
```julia
logmetric(instance::MLFlow, run::Run, key::String, value::Float64; timestamp, step)
```

## Solution
Updated to log each array element individually with step parameter:
```julia
# Log each point in the price path as a separate metric with step parameter
for (step, value) in enumerate(pricepath)
    logmetric(mlf, exprun, "pricepath$(idx)", Float64(value); step=step-1)
end
```

## Benefits
- ✅ Fixes the type error that prevented tutorial execution
- ✅ Maintains original intent of logging price paths over time
- ✅ Uses MLFlow's step parameter to track temporal sequence
- ✅ Creates proper time-series metrics that can be visualized in MLFlow UI
- ✅ Follows `logmetric` API requirements

## Impact
- Makes the tutorial examples functional for metric logging
- Provides better MLFlow visualization of time-series data
- Demonstrates proper usage of MLFlow's step parameter for sequential data

## Test plan
- [x] Verified `logmetric` method signature requires `Float64` values
- [x] Confirmed step parameter usage for time-series data
- [x] Both tutorial and example files updated consistently
- [x] Solution maintains the intended data logging semantics

Fixes #63

🤖 Generated with [Claude Code](https://claude.ai/code)